### PR TITLE
Change from short to standard open tag

### DIFF
--- a/example5_clicktocall.php
+++ b/example5_clicktocall.php
@@ -1,4 +1,4 @@
-<?
+<?php
 // DIY Click-To-Call using the 46elks platform
 
 function newCall ($call) {


### PR DESCRIPTION
Change from short to standard open tag

https://wiki.php.net/rfc/deprecate_php_short_tags