### PR TITLE
Change from short to standard open tag

### DIFF
--- a/example2_groupsms.php
+++ b/example2_groupsms.php
@@ -1,4 +1,4 @@
-<?
+<?php
 // "Roll your own" SMS group messaging on the 46elks platform
 // 
 // Allocated one or two numbers using the /Numbers REST resource, and update


### PR DESCRIPTION
Change from short to standard open tag
https://wiki.php.net/rfc/deprecate_php_short_tags